### PR TITLE
Added pip install pyopenssl in Dockerfile (for unit tests)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -35,7 +35,11 @@ RUN cd /workspaces/ \
 
 COPY .devcontainer/settings.py /workspaces/stac-fastapi-elasticsearch/stac_fastapi/elasticsearch/settings.py
 
+# Update packages so unit tests work in container
+RUN pip install --upgrade pip pyopenssl
+
 # Mark installed repos as safe
 RUN git config --system --add safe.directory /workspaces/pystac
 RUN git config --system --add safe.directory /workspaces/pystac-client
 RUN git config --system --add safe.directory /workspaces/stac-fastapi-elasticsearch
+


### PR DESCRIPTION
Hi @rhysrevans3,

I've made a slight adjustment. My unit tests (in `esgf-stac-client`) didn't run without upgrading `pyopenssl` so added that to the `Dockerfile`.